### PR TITLE
Fix user engagement tracking on path change in the AnalyticsTracker

### DIFF
--- a/app/_components/AnalyticsTracker.tsx
+++ b/app/_components/AnalyticsTracker.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
-import { setUserAnalyticsProperties, trackAppOpen } from "@/app/_lib/analytics";
+import { setUserAnalyticsProperties, trackAppOpen, trackPageView } from "@/app/_lib/analytics";
 import { AppUser } from "../_types/types";
 
 // Api routes are a bridge for the functions for analytics-admin.ts
@@ -41,6 +41,8 @@ export default function AnalyticsTracker({
   const pathname = usePathname();
   const lastActivityTime = useRef(Date.now());
   const sessionIdRef = useRef<string | null>(null);
+  const pageStartTime = useRef(Date.now());
+  const currentFeature = useRef<string>("");
 
   useEffect(() => {
     if (!userData?.uid) return;
@@ -52,8 +54,15 @@ export default function AnalyticsTracker({
         return;
       }
 
+      // Track app open in Firebase Analytics
       trackAppOpen();
+      
       const feature = getFeatureFromPath(pathname);
+      currentFeature.current = feature;
+      
+      // Track initial page view in Firebase Analytics
+      trackPageView(feature, pathname);
+      
       const data = await postToServer("session/start", {
         userId: userData.uid,
         pageTitle: feature,
@@ -63,7 +72,15 @@ export default function AnalyticsTracker({
         sessionIdRef.current = data.sessionId;
         sessionStorage.setItem("sessionId", data.sessionId);
       }
+      
+      // Track initial feature usage
+      await postToServer("feature", {
+        userId: userData.uid,
+        feature: feature,
+        duration: 0, // Initial load
+      });
     };
+    
     const updateUserProperties = async () => {
       try {
         setUserAnalyticsProperties({
@@ -83,6 +100,18 @@ export default function AnalyticsTracker({
 
     const endSession = () => {
       if (sessionIdRef.current) {
+        // Calculate time spent on current page before ending session
+        const timeSpentOnPage = Math.round((Date.now() - pageStartTime.current) / 1000);
+        
+        // Track final feature usage before ending session
+        if (currentFeature.current && timeSpentOnPage > 0) {
+          postToServer("feature", {
+            userId: userData.uid,
+            feature: currentFeature.current,
+            duration: timeSpentOnPage,
+          });
+        }
+
         const payload = JSON.stringify({
           sessionId: sessionIdRef.current,
         });
@@ -94,11 +123,36 @@ export default function AnalyticsTracker({
 
     const handleVisibilityChange = () => {
       if (document.visibilityState === "hidden") {
+        // Calculate time spent before hiding
+        const timeSpentOnPage = Math.round((Date.now() - pageStartTime.current) / 1000);
+        
+        if (sessionIdRef.current && timeSpentOnPage > 0) {
+          // Update session with time spent
+          postToServer("session/update", {
+            sessionId: sessionIdRef.current,
+            pageTitle: currentFeature.current,
+            timeSpent: timeSpentOnPage,
+          });
+          
+          // Track feature usage
+          postToServer("feature", {
+            userId: userData.uid,
+            feature: currentFeature.current,
+            duration: timeSpentOnPage,
+          });
+        }
+        
         endSession();
       } else {
+        // Reset timers when page becomes visible again
         lastActivityTime.current = Date.now();
+        pageStartTime.current = Date.now();
       }
     };
+
+    // Reset page start time for initial load
+    pageStartTime.current = Date.now();
+    lastActivityTime.current = Date.now();
 
     startSession();
     updateUserProperties();
@@ -110,21 +164,44 @@ export default function AnalyticsTracker({
       window.removeEventListener("beforeunload", endSession);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [userData?.uid, pathname]);
+  }, [userData?.uid]); // Removed pathname from dependency to avoid restart on route change
 
+  // Handle pathname changes separately to properly track page transitions
   useEffect(() => {
-    if (sessionIdRef.current) {
-      const timeSpent = Math.round(
-        (Date.now() - lastActivityTime.current) / 1000
-      );
+    if (!userData?.uid || !sessionIdRef.current) return;
+
+    const newFeature = getFeatureFromPath(pathname);
+    
+    // Calculate time spent on previous page
+    const timeSpentOnPreviousPage = Math.round((Date.now() - pageStartTime.current) / 1000);
+    
+    // Track feature usage for previous page if we spent meaningful time there
+    if (currentFeature.current && timeSpentOnPreviousPage > 1) {
+      postToServer("feature", {
+        userId: userData.uid,
+        feature: currentFeature.current,
+        duration: timeSpentOnPreviousPage,
+      });
+    }
+
+    // Update session with page transition
+    if (timeSpentOnPreviousPage > 0) {
       postToServer("session/update", {
         sessionId: sessionIdRef.current,
-        pageTitle: getFeatureFromPath(pathname),
-        timeSpent,
+        pageTitle: newFeature,
+        timeSpent: timeSpentOnPreviousPage,
       });
-      lastActivityTime.current = Date.now();
     }
-  }, [pathname]);
+    
+    // Track new page view in Firebase Analytics
+    trackPageView(newFeature, pathname);
+    
+    // Update current feature and reset timers
+    currentFeature.current = newFeature;
+    pageStartTime.current = Date.now();
+    lastActivityTime.current = Date.now();
+    
+  }, [pathname, userData?.uid]);
 
   return null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {


### PR DESCRIPTION
Fixes user engagement tracking to record real-time active and duration values by ensuring analytics calls on page transitions and visibility changes.

Previously, `activeTime` and `duration` were often recorded as zero due to missing `trackPageView` calls, incorrect time calculations, and incomplete feature usage tracking. This update refactors `AnalyticsTracker` to accurately capture time spent on pages and features, and correctly manage user sessions across navigation and visibility changes.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-79727081-21f7-44d2-b076-6073554aaba9) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-79727081-21f7-44d2-b076-6073554aaba9)